### PR TITLE
Revert "Wrap README prose at 80 columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # Heroku Cloud Native Buildpacks: Node.js
 
-[![Cloud Native Buildpacks Registry:
-heroku/nodejs][registry-badge]][registry-url] [![CI on Github Actions:
-heroku/nodejs][ci-badge]][ci-url]
+[![Cloud Native Buildpacks Registry: heroku/nodejs][registry-badge]][registry-url]
+[![CI on Github Actions: heroku/nodejs][ci-badge]][ci-url]
 
 ![Heroku Cloud Native Buildpack: heroku/nodejs][cnb-banner]
 
-This repository is the home of [Heroku Cloud Native
-Buildpacks][heroku-buildpacks] for Node.js applications. These buildpacks build
-Node.js application source code into application images with minimal
-configuration.
+This repository is the home of [Heroku Cloud Native Buildpacks][heroku-buildpacks]
+for Node.js applications. These buildpacks build Node.js application source code
+into application images with minimal configuration.
 
 > [!IMPORTANT]
 > This is a collection of [Cloud Native Buildpacks][cnb], and is a component of the [Heroku Cloud Native Buildpacks][heroku-buildpacks] project, which is in preview. If you are instead looking for the Heroku Classic Buildpack for Node.js (for use on the Heroku platform), you may find it [here][classic-buildpack].
@@ -34,8 +32,8 @@ docker run --rm -it -e "PORT=8080" -p 8080:8080 sample-app
 
 ## Application Requirements
 
-The `heroku/nodejs` buildpack requires a valid `package.json` to be present to
-build.
+The `heroku/nodejs` buildpack requires a valid `package.json` to be present
+to build.
 
 In order to install dependencies, a vaild `npm`, `yarn`, or `pnpm` lockfile must
 be present.
@@ -59,8 +57,8 @@ For example, to select the latest releasse in the Node.js 20 line, modify your
 
 This field supports the same semantic versioning syntax as `package.json`.
 
-If no Node.js version is specified, the latest LTS version will be used. We
-highly suggest specifying a version to prevent surprise changes.
+If no Node.js version is specified, the latest LTS version will be used.
+We highly suggest specifying a version to prevent surprise changes.
 
 ## Included Buildpacks
 
@@ -84,8 +82,7 @@ functionality of the independent buildpacks.
 
 ## Contributing
 
-Issues and pull requests are welcome. See our [contributing
-guidelines](./CONTRIBUTING.md) if you would like to help.
+Issues and pull requests are welcome. See our [contributing guidelines](./CONTRIBUTING.md) if you would like to help.
 
 
 [ci-badge]: https://github.com/heroku/buildpacks-nodejs/actions/workflows/ci.yml/badge.svg


### PR DESCRIPTION
**Description**

- Removed: reverts the 80-column README prose wrapping.

Restores `README.md` to its content from before the wrap commit, taken from git
history (the parent of that commit) rather than from a working copy.

Reverting so the wrapping can be redone at 120 columns from the original text.
Re-wrapping the already-wrapped file is not equivalent — wrapping at 80 can
split a line so short that re-wrapping at 120 cannot rejoin it, which affects 5
of 266 READMEs. Going back to the original avoids that.

Only `README.md` is touched.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary label (patch/minor/major - If package publish is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
